### PR TITLE
add convenience default init for dequeueReusableCell

### DIFF
--- a/AUPickerCell/AUPickerCell/AUPickerCell.swift
+++ b/AUPickerCell/AUPickerCell/AUPickerCell.swift
@@ -358,7 +358,7 @@ public class AUPickerCell: UITableViewCell {
   }
  
   override convenience init(style: UITableViewCellStyle, reuseIdentifier: String?) {
-     self.init(type: pickerType, reuseIdentifier: reuseIdentifier)
+     self.init(type: .default, reuseIdentifier: reuseIdentifier)
   }
   
   /**

--- a/AUPickerCell/AUPickerCell/AUPickerCell.swift
+++ b/AUPickerCell/AUPickerCell/AUPickerCell.swift
@@ -356,6 +356,10 @@ public class AUPickerCell: UITableViewCell {
     pickerType = .default
     initialize()
   }
+ 
+  override convenience init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+     self.init(type: pickerType, reuseIdentifier: reuseIdentifier)
+  }
   
   /**
    Initializes and returns a newly allocated table cell object with the specified type of picker view embedded inside. This is the designated initializer for the class.


### PR DESCRIPTION
the compiler suggests TableViewCell should implement its default init.